### PR TITLE
Fixed the  "dotenv.load() is not a function" error

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 if (process.env.NODE_ENV !== 'production') {
-  require('dotenv').load()
+  require('dotenv').config()
 }
 
 const stripeSecretKey = process.env.STRIPE_SECRET_KEY


### PR DESCRIPTION
To overcome the `dotenv.load() is not a function" error while trying to run a Node script, we should now use the `dotenv.config()`.
Please refer here to the NPM documentation (https://www.npmjs.com/package/dotenv)